### PR TITLE
Fix reload loop and hide trending topics

### DIFF
--- a/Chrome Extension/css/hider.css
+++ b/Chrome Extension/css/hider.css
@@ -1,5 +1,7 @@
-#topnews_main_stream_408239535924329,
-#u_jsonp_10_2 {
-    display: none !important;
+#pagelet_trending_tags_and_topics, #topnews_main_stream_408239535924329, #u_jsonp_10_2 {
+    visibility: hidden !important;
     font-size: 0 !important;
+}
+#pagelet_trending_tags_and_topics, #u_jsonp_10_2 {
+  display: none !important;
 }

--- a/Chrome Extension/js/main.js
+++ b/Chrome Extension/js/main.js
@@ -1,15 +1,16 @@
 (function(){
 
 document.addEventListener("DOMContentLoaded", function(event) {
-	var newsfeed = document.getElementById('topnews_main_stream_408239535924329');
-  if (newsfeed) {
-    hideElement(newsfeed);
-  }
+	var idsToHide = ['pagelet_trending_tags_and_topics', 'topnews_main_stream_408239535924329'];
+	for (int i = 0; i < idsToHide.length; i++) {
+		var item = document.getElementById('topnews_main_stream_408239535924329');
+		if (item) {
+			hideElement(item);
+		}
+	}
 });
 
 function hideElement(el) {
 	el.parentNode.removeChild(el);
 }
-
 }());
-

--- a/Chrome Extension/js/main.js
+++ b/Chrome Extension/js/main.js
@@ -1,16 +1,1 @@
-(function(){
-
-document.addEventListener("DOMContentLoaded", function(event) {
-	var idsToHide = ['pagelet_trending_tags_and_topics', 'topnews_main_stream_408239535924329'];
-	for (int i = 0; i < idsToHide.length; i++) {
-		var item = document.getElementById('topnews_main_stream_408239535924329');
-		if (item) {
-			hideElement(item);
-		}
-	}
-});
-
-function hideElement(el) {
-	el.parentNode.removeChild(el);
-}
-}());
+// No Javascript required - see CSS.


### PR DESCRIPTION
When the newsfeed is set to display:none Facebook continuously tries to reload more results. However, setting visibility as hidden does not cause a reload loop. I also hid trending topics from the right side bar. The Javascript wasn't accomplishing anything, probably because it was run before the news feed loads.
